### PR TITLE
Add install to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 ![Screenshot](https://raw.githubusercontent.com/moyicat/inkdrop-code-fold/master/Screenshot.png)
 
+### Install
+```
+ipm install code-fold
+```
+
 ### Shortcuts
 
 Shift + Command + e / Shift + Control + e: Fold all


### PR DESCRIPTION
Add install help to README to match other inkdrop plugin README conventions.