### PR TITLE
chore: use `@electron/remote` instead of require('electron').remote

### DIFF
--- a/lib/code-fold.js
+++ b/lib/code-fold.js
@@ -1,4 +1,4 @@
-const app = require('electron').remote.app;
+const app = require('@electron/remote').app;
 const modulePath = app.getAppPath() + '/node_modules/'
 require(modulePath + 'codemirror/addon/fold/foldcode.js');
 require(modulePath + 'codemirror/addon/fold/foldgutter.js');


### PR DESCRIPTION
So, Electron removed the property `remote` from their main package and the plugin stopped working.
Those changes bring it to life.